### PR TITLE
WIP: Feature/soft takeover

### DIFF
--- a/src/mode/mode_struct.rs
+++ b/src/mode/mode_struct.rs
@@ -1220,10 +1220,6 @@ impl<T: Transformation> Mode<T> {
         //    the individual controller values never actually fall inside the Jump Max range.
         // 3) Enable a typical "set and forget" Jump Max of 3% or less without sync loss.
         //
-        // Approaching is detected by either a quick movement from outside Jump Max to
-        // inside it (both on the same side of the target), OR a slow movement (whose step
-        // timings may exceed TIMEOUT due to coarse 0-127 resolution) within Jump Max.
-        //
         // Inspired by controllers/softtakeover.cpp in the Mixxx DJ project.
 
         if current_distance.abs() <= jump_max.get() && !approaching_target {

--- a/src/mode/mode_struct.rs
+++ b/src/mode/mode_struct.rs
@@ -1213,6 +1213,12 @@ impl<T: Transformation> Mode<T> {
             return true;
         }
 
+        // If Jump Max = 100% then we are in sync by definition. (movements less than Jump
+        // Min will be handled downstream of this)
+        if jump_max.is_one() {
+            return true;
+        }
+
         // New takeover logic. Goals:
         //
         // 1) Avoid awkward "backwards" jumps when approaching the target.

--- a/src/mode/mode_struct.rs
+++ b/src/mode/mode_struct.rs
@@ -1210,7 +1210,6 @@ impl<T: Transformation> Mode<T> {
 
         // If we were in sync less than CONTROL_MOVE_TIMEOUT ms ago, stay in sync
 	    if in_sync && !time_expired {
-            println!("Already in sync");
             return true;
         }
 
@@ -1226,8 +1225,6 @@ impl<T: Transformation> Mode<T> {
         // timings may exceed TIMEOUT due to coarse 0-127 resolution) within Jump Max.
         //
         // Inspired by controllers/softtakeover.cpp in the Mixxx DJ project.
-
-        println!("cd {} pd {} ss {} at {} te {}", current_distance, prev_distance, same_side, approaching_target, time_expired);
 
         if current_distance.abs() <= jump_max.get() && !approaching_target {
             return true;
@@ -1292,7 +1289,6 @@ impl<T: Transformation> Mode<T> {
             current_target_value.to_unit_value(),
             self.state.takeover_in_sync,
         );
-        println!("result of in_sync: {}", in_sync);
 
         // Check for controller jumps. For fast movements, the time won't be expired between messages.
         // For slow movements, the delta between the previous and current values will be under Jump Max.


### PR DESCRIPTION
Hi @helgoboss,

This patch implements several improvements for using absolute physical controllers (non-motorized faders and traditional non-endless knobs). Pending any issues that may come up in further testing, it is ready for review/cleanup to better fit the project.

This addresses https://github.com/helgoboss/realearn/issues/485.

- In Pick Up mode:
  - The software control no longer suddenly jumps backwards to meet the physical control as the physical control approaches the target value.
  - The software control now keeps up with quick physical movements that previously desynced due to exceeding the Max Jump threshold from one CC message to the next.
- In Long Time No See mode:
  - The software control now keeps up with quick physical movements that previously desynced due to exceeding the Max Jump threshold from one CC message to the next.
- In Parallel and Catch Up modes:
  - When switching between software targets for the same physical control, the newly-targeted software control no longer makes incorrect jumps based on the difference between the last-seen position of the physical control (just before it switched targets) and its now-irrelevant current position.

Thank you!

Matt